### PR TITLE
fix: adjust output to handle whitespace values of `href` and `image` better by trimming and omitting them

### DIFF
--- a/lib/chapters/chapter.ex
+++ b/lib/chapters/chapter.ex
@@ -23,9 +23,17 @@ defmodule Chapters.Chapter do
 
   @doc """
   Produces an ordered keylist `:start, :title, :href, :image` with the start already formatted top a normal playtime for use in output formats
+
+  iex> %Chapters.Chapter{href: "//foo", image: nil, start: 1234, title: "Title"} |> Chapter.to_keylist()
+  [start: "00:00:01.234", title: "Title", href: "//foo"]
+
+  iex> %Chapters.Chapter{href: "", image: "//foo.jpeg", start: 1234, title: "Title"} |> Chapter.to_keylist()
+  [start: "00:00:01.234", title: "Title", image: "//foo.jpeg"]
   """
 
   def to_keylist(%__MODULE__{} = chapter) do
+    chapter = sanitize(chapter)
+
     [
       start:
         chapter.start
@@ -34,6 +42,34 @@ defmodule Chapters.Chapter do
     ]
     |> maybe_put(:href, chapter.href)
     |> maybe_put(:image, chapter.image)
+  end
+
+  @doc """
+  Sanitizes the href and image values. Trims them and nils them out if they are an empty string.
+
+      iex> %Chapters.Chapter{href: " //foo ", image: " ", start: 0, title: "Title"} |> Chapter.sanitize()
+      %Chapters.Chapter{href: "//foo", image: nil, start: 0, title: "Title"}
+
+      iex> %Chapters.Chapter{href: "   ", image: "  ", start: 0, title: "Title"} |> Chapter.sanitize()
+      %Chapters.Chapter{href: nil, image: nil, start: 0, title: "Title"}
+
+  """
+
+  def sanitize(chapter = %__MODULE__{}) do
+    [:href, :image]
+    |> Enum.reduce(chapter, fn key, acc ->
+      case Map.get(acc, key) do
+        nil ->
+          acc
+
+        value ->
+          case String.trim(value) do
+            "" -> Map.put(acc, key, nil)
+            ^value -> acc
+            trimmed -> Map.put(acc, key, trimmed)
+          end
+      end
+    end)
   end
 
   defp maybe_put(keylist, _key, nil), do: keylist

--- a/lib/formatters/json/formatter.ex
+++ b/lib/formatters/json/formatter.ex
@@ -11,7 +11,7 @@ defmodule Chapters.Formatters.Json.Formatter do
       chapter_map = chapter |> Chapter.to_keylist() |> Map.new()
 
       # to facilitate ordering, the list of keys to take needs to be static
-      case {chapter.image, chapter.href} do
+      case {chapter_map[:image], chapter_map[:href]} do
         {nil, nil} -> json_map_take(chapter_map, [:start, :title])
         {_im, nil} -> json_map_take(chapter_map, [:start, :title, :image])
         {nil, _ur} -> json_map_take(chapter_map, [:start, :title, :href])

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Chapters.MixProject do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.0.1"
   @url "https://github.com/podlove/chapters"
 
   def project do

--- a/test/chapters_test.exs
+++ b/test/chapters_test.exs
@@ -1,7 +1,8 @@
 defmodule ChaptersTest do
   use ExUnit.Case
-
   alias Chapters.Chapter
+
+  doctest Chapters.Chapter
 
   @psc_chapters ~S"""
   <psc:chapters version="1.2" xmlns:psc="http://podlove.org/simple-chapters">


### PR DESCRIPTION
add: doctests
change: bumped version to suggest a hex.pm release

fixes #3